### PR TITLE
useEffect observes an object when it should observe object properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10811,7 +10811,7 @@
     },
     "packages/react": {
       "name": "@photonhealth/react",
-      "version": "0.1.12",
+      "version": "0.1.27",
       "license": "ISC",
       "devDependencies": {
         "@types/react": "^18.0.17",
@@ -10822,7 +10822,7 @@
     },
     "packages/sdk": {
       "name": "@photonhealth/sdk",
-      "version": "0.1.12",
+      "version": "0.1.27",
       "license": "ISC",
       "dependencies": {
         "@apollo/client": "^3.6.9",

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1906,7 +1906,7 @@ export const PhotonProvider = (opts: {
 
     useEffect(() => {
       fetchPharmacies({ name, location, type, after, first })
-    }, [name, location, type])
+    }, [name, location?.latitude, location?.longitude, location?.radius, type])
 
     return {
       pharmacies,


### PR DESCRIPTION
Introduced in #54, the useEffect should instead observe `location.latitude` instead of `location` (etc) since observing an object in useEffect often results in behavior you don't intend/expect.