### PR TITLE
add trackingNumber + carrier to the getOrder fragment

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,2 @@
 export { usePhoton, PhotonProvider } from "./provider"
-
 export { PhotonClient, types, fragments } from "@photonhealth/sdk"

--- a/packages/sdk/src/fragments.ts
+++ b/packages/sdk/src/fragments.ts
@@ -169,6 +169,8 @@ export const ORDER_FIELDS = gql`
     fulfillment {
       type
       state
+      carrier
+      trackingNumber
     }
     createdAt
   }


### PR DESCRIPTION
Adds the following fields to the order fragment for the Order Details page in the Clinical App:
- trackingNumber
- carrier